### PR TITLE
Refactor: Removing Component Retrieval from Hook and Deprecation Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ export const TodoList = () => {
 
 ## 🧩 Components (so far...)
 
-This package contains a few components for working with Direcuts files [file access](https://docs.directus.io/reference/files/). They are all configured for using the `apiUrl` specified in the provider. Hopefully, more will come in the future 🤗.
+This package contains a few components for working with Direcuts [files](https://docs.directus.io/reference/files/). They are all configured for using the `apiUrl` specified in the provider. Hopefully, more will come in the future 🤗.
 
 > **Note**: components can also be used in a "standalone" way, meaning that they are not bound to the `apiUrl` specified in the provider. In that case, they both accept an `apiUrl` prop.
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ export const TodoList = () => {
 
 ## 🧩 Components (so far...)
 
-The hook exports a few components for working with Direcuts files [file access](https://docs.directus.io/reference/files/). They are all configured for using the `apiUrl` specified in the provider. Hopefully, more will come in the future 🤗.
+This package contains a few components for working with Direcuts files [file access](https://docs.directus.io/reference/files/). They are all configured for using the `apiUrl` specified in the provider. Hopefully, more will come in the future 🤗.
 
-> All components, when imported from `react-directus` directly (i.e. not imported using the hook `useDirectus`), can be used in a "standalone" way. It means that they are not bound to the `apiUrl` specified in the provider. In that case, they both accept an `apiUrl` prop.
+> All components can be used in a "standalone" way. It means that they are not bound to the `apiUrl` specified in the provider. In that case, they both accept an `apiUrl` prop.
 
 ### `<DirectusAsset>`
 
@@ -93,11 +93,9 @@ Computes the URL of the given resource `asset`, rendering it using the `render` 
 
 ```jsx
 import React from 'react';
-import { useDirectus } from 'react-directus';
+import { DirectusAsset } from 'react-directus';
 
 export const TodoItem = ({ item }) => {
-  const { DirectusAsset } = useDirectus();
-
   return (
     <div>
       <h1>Todo #{item.id}</h1>
@@ -121,11 +119,9 @@ Computes the URL of the given resource `asset`, rendering it using the `render` 
 
 ```jsx
 import React from 'react';
-import { useDirectus } from 'react-directus';
+import { DirectusImage } from 'react-directus';
 
 export const TodoItem = ({ item }) => {
-  const { DirectusImage } = useDirectus();
-
   return (
     <div>
       <h1>Todo #{item.id}</h1>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ export const TodoList = () => {
 
 This package contains a few components for working with Direcuts files [file access](https://docs.directus.io/reference/files/). They are all configured for using the `apiUrl` specified in the provider. Hopefully, more will come in the future 🤗.
 
-> All components can be used in a "standalone" way. It means that they are not bound to the `apiUrl` specified in the provider. In that case, they both accept an `apiUrl` prop.
+> **Note**: components can also be used in a "standalone" way, meaning that they are not bound to the `apiUrl` specified in the provider. In that case, they both accept an `apiUrl` prop.
 
 ### `<DirectusAsset>`
 

--- a/src/DirectusAsset.tsx
+++ b/src/DirectusAsset.tsx
@@ -10,13 +10,13 @@ export const DirectusAsset = ({
   render,
 }: DirectusAssetProps): JSX.Element => {
   const directusContext = React.useContext(DirectusContext);
-  let params = {};
-  if (download) {
-    params = { ...params, download: '' };
-  }
 
   if (!directusContext && !propsApiUrl) {
     throw new Error('DirectusAsset requires either a DirectusProvider or an apiUrl prop');
+  }
+  let params = {};
+  if (download) {
+    params = { ...params, download: '' };
   }
 
   const apiUrl = propsApiUrl || directusContext?.apiUrl;

--- a/src/DirectusAsset.tsx
+++ b/src/DirectusAsset.tsx
@@ -14,12 +14,13 @@ export const DirectusAsset = ({
   if (!directusContext && !propsApiUrl) {
     throw new Error('DirectusAsset requires either a DirectusProvider or an apiUrl prop');
   }
+
   let params = {};
   if (download) {
     params = { ...params, download: '' };
   }
 
-  const apiUrl = propsApiUrl || directusContext?.apiUrl;
+  const apiUrl = propsApiUrl || directusContext.apiUrl;
 
   return render({
     apiUrl,

--- a/src/DirectusAsset.tsx
+++ b/src/DirectusAsset.tsx
@@ -15,12 +15,11 @@ export const DirectusAsset = ({
     throw new Error('DirectusAsset requires either a DirectusProvider or an apiUrl prop');
   }
 
+  const apiUrl = propsApiUrl || directusContext.apiUrl;
   let params = {};
   if (download) {
     params = { ...params, download: '' };
   }
-
-  const apiUrl = propsApiUrl || directusContext.apiUrl;
 
   return render({
     apiUrl,

--- a/src/DirectusAsset.tsx
+++ b/src/DirectusAsset.tsx
@@ -1,10 +1,25 @@
-import { DirectusAssetProps } from './types';
+import * as React from 'react';
 
-export const DirectusAsset = ({ apiUrl, asset, download = false, render }: DirectusAssetProps): JSX.Element => {
+import { DirectusAssetProps } from './types';
+import { DirectusContext } from './DirectusProvider';
+
+export const DirectusAsset = ({
+  apiUrl: propsApiUrl,
+  asset,
+  download = false,
+  render,
+}: DirectusAssetProps): JSX.Element => {
+  const directusContext = React.useContext(DirectusContext);
   let params = {};
   if (download) {
     params = { ...params, download: '' };
   }
+
+  if (!directusContext && !propsApiUrl) {
+    throw new Error('DirectusAsset requires either a DirectusProvider or an apiUrl prop');
+  }
+
+  const apiUrl = propsApiUrl || directusContext?.apiUrl;
 
   return render({
     apiUrl,

--- a/src/DirectusImage.tsx
+++ b/src/DirectusImage.tsx
@@ -10,7 +10,7 @@ export const DirectusImage = ({ apiUrl: propsApiUrl, asset, render, ...params }:
     throw new Error('DirectusAsset requires either a DirectusProvider or an apiUrl prop');
   }
 
-  const apiUrl = propsApiUrl || directusContext?.apiUrl;
+  const apiUrl = propsApiUrl || directusContext.apiUrl;
 
   return render({
     apiUrl,

--- a/src/DirectusImage.tsx
+++ b/src/DirectusImage.tsx
@@ -1,6 +1,17 @@
+import * as React from 'react';
+
+import { DirectusContext } from './DirectusProvider';
 import { DirectusImageProps } from './types';
 
-export const DirectusImage = ({ apiUrl, asset, render, ...params }: DirectusImageProps): JSX.Element => {
+export const DirectusImage = ({ apiUrl: propsApiUrl, asset, render, ...params }: DirectusImageProps): JSX.Element => {
+  const directusContext = React.useContext(DirectusContext);
+
+  if (!directusContext && !propsApiUrl) {
+    throw new Error('DirectusAsset requires either a DirectusProvider or an apiUrl prop');
+  }
+
+  const apiUrl = propsApiUrl || directusContext?.apiUrl;
+
   return render({
     apiUrl,
     asset,

--- a/src/DirectusProvider.tsx
+++ b/src/DirectusProvider.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  DirectusAssetProps,
-  DirectusAssetPropsContextualized,
-  DirectusContextTpye,
-  DirectusImageProps,
-  DirectusProviderProps,
-} from './types';
+import { DirectusAssetProps, DirectusContextTpye, DirectusImageProps, DirectusProviderProps } from './types';
 import { Directus } from '@directus/sdk';
 import { DirectusAsset } from './DirectusAsset';
 import { DirectusImage } from './DirectusImage';
@@ -17,12 +11,14 @@ export const DirectusProvider = ({ apiUrl, options, children }: DirectusProvider
     () => ({
       apiUrl: apiUrl,
       directus: new Directus(apiUrl, options),
-      DirectusAsset: (props: DirectusAssetPropsContextualized<DirectusAssetProps>): JSX.Element => (
-        <DirectusAsset apiUrl={apiUrl} {...props} />
-      ),
-      DirectusImage: (props: DirectusAssetPropsContextualized<DirectusImageProps>): JSX.Element => (
-        <DirectusImage apiUrl={apiUrl} {...props} />
-      ),
+      DirectusAsset: ({ asset, render, ...props }: DirectusAssetProps) => {
+        console.warn('Deprecated: Please import DirectusAsset directly from react-directus');
+        return <DirectusAsset asset={asset} render={render} {...props} />;
+      },
+      DirectusImage: ({ asset, render, ...props }: DirectusImageProps) => {
+        console.warn('Deprecated: Please import DirectusImage directly from react-directus');
+        return <DirectusImage asset={asset} render={render} {...props} />;
+      },
     }),
     [apiUrl]
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type DirectusAssetRenderer = Omit<DirectusAssetProps, 'render'> & {
  */
 export interface DirectusAssetProps {
   /** Directus CMS API url. */
-  apiUrl: string;
+  apiUrl?: string;
   /** The asset as `string` or `object` with an `id` property of type `string`. */
   asset: DirectusAsset;
   /** Add `Content-Disposition` header and force browser to download file. */
@@ -52,12 +52,6 @@ export interface DirectusImageProps extends Omit<DirectusAssetProps, 'download' 
   /** A function that returns the React element to be rendered. It will receive an object with the `url` key and all the passed props. */
   render: (args: DirectusImageRenderer) => JSX.Element;
 }
-
-/**
- * Shape of the context-aware `DirectusAsset` component props.
- */
-export type DirectusAssetPropsContextualized<T extends DirectusAssetProps> = Omit<T, 'apiUrl'> &
-  Pick<Partial<T>, 'apiUrl'>;
 
 /**
  * Shape of the context provider props.


### PR DESCRIPTION
#### 🔧 Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

- [x] I've read the [guidelines for contributing](https://github.com/gremo/react-directus/blob/main/CONTRIBUTING.md)
- [x] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description

This pull request includes the following changes:
1. **Removed Component Retrieval from Hook**: I have refactored the codebase to eliminate the need to get components directly from the hook while still exporting them for backward compatibility. 
   > With the new model, the components now get the `apiUrl` either from the `DirectusContext` or via the `apiUrl` prop. If both are specified, the `apiUrl` prop takes priority. If neither is specified, an error is thrown.

2. **Updated the README**: The README file has been updated to reflect the new approach for accessing components, providing clear instructions on how to adapt existing code.

3. **Deprecation Warnings in Console**: To ensure a smooth transition, I have added deprecation warnings in the console when attempting to retrieve components from the hook. This will notify users about the preferred method of accessing components.