### PR TITLE
Update: Getting Started in README for React 18 (Issue #352)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,16 @@ The `<DirectusProvider>` component makes the [Directus JavaScript SDK](https://d
 ```jsx
 import { App } from './App';
 import { DirectusProvider } from 'react-directus';
-import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
-ReactDOM.render(
+const container = document.getElementById('root');
+
+const root = createRoot(container);
+
+root.render(
   <DirectusProvider apiUrl="https://api.example.com" options={{}}>
     <App />
-  </DirectusProvider>,
-  document.getElementById('root')
+  </DirectusProvider>
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ import { App } from './App';
 import { DirectusProvider } from 'react-directus';
 import { createRoot } from 'react-dom/client';
 
-const container = document.getElementById('root');
-
-const root = createRoot(container);
+const root = createRoot(document.getElementById('root'));
 
 root.render(
   <DirectusProvider apiUrl="https://api.example.com" options={{}}>


### PR DESCRIPTION
#### 🔧 Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

- [x] I've read the [guidelines for contributing](https://github.com/gremo/react-directus/blob/main/CONTRIBUTING.md)
- [x] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description

This pull request addresses Issue #352 by updating the "Getting Started" section in the README to reflect the changes required for React 18 compatibility. As per the React 18 upgrade guide mentioned in the issue (https://react.dev/blog/2022/03/08/react-18-upgrade-guide), we have modified the instructions and dependencies to ensure a smooth transition to React 18.
