### PR TITLE
[Codebase]: GitHub Action: Publishing to NPM

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,34 @@
+name: npm-publish
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: npm ci
+        
+    - name: Run clean
+      run: npm run clean
+
+    - name: Run build
+      run: npm run build
+    
+    - name: Publish to NPM
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,19 +1,20 @@
-name: npm-publish
+name: Publish to NPM
+
 on:
   push:
     branches:
       - main
     tags:
       - 'v*.*.*'
+
 jobs:
-  npm-publish:
-    name: npm-publish
+  publish:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
+    - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Setup Node.js
+    - name: Setup Node.js environment
       uses: actions/setup-node@v3
       with:
         node-version: 18
@@ -21,14 +22,14 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
-        
-    - name: Run clean
+
+    - name: Clean
       run: npm run clean
 
-    - name: Run build
+    - name: Build
       run: npm run build
-    
-    - name: Publish to NPM
+
+    - name: Publish
       run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
#### 🔧 Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Codebase improvement
- [ ] Other (if none of the other choices apply)

#### 🚨 Checklist

- [x] I've read the [guidelines for contributing](https://github.com/gremo/react-directus/blob/main/CONTRIBUTING.md)
- [x] I've added necessary documentation (if appropriate)
- [x] I've ensured that my code additions do not fail linting or unit tests (if applicable)

#### Description

This pull request addresses issue:
 - #380

I have added a GitHub Action for publishing to NPM. The action requires the `NPM_AUTH_TOKEN`, which will be used for authentication during the publishing process. To ensure security, I have not included the token directly in the workflow file. Instead, you will need to generate an NPM token and add it to your repository's secrets (Settings -> Secrets). The action will then access the token from the secrets and use it for authentication to NPM.

Please review the changes and let me know if there are any other requirements or adjustments needed.

Thank you for considering this pull request, and I look forward to your feedback on the GitHub Action implementation.

